### PR TITLE
feat(hardlinks): Track duplicate files identified by SameFile and dlink all duplicates

### DIFF
--- a/gourd.go
+++ b/gourd.go
@@ -9,8 +9,9 @@ import (
 type (
 	// File is a path and FileInfo.
 	File struct {
-		Path     string
-		FileInfo os.FileInfo
+		Path           string
+		FileInfo       os.FileInfo
+		DuplicatePaths []string
 	}
 
 	// Bucket is a list of Files sharing common attributes

--- a/samefile.go
+++ b/samefile.go
@@ -27,9 +27,10 @@ func (bm SameFilterBucketer) Bucket(in Buckets) (Buckets, error) {
 		for _, toTest := range bucket {
 			toTestFi := toTest.FileInfo
 			duplicate := false
-			for _, filteredFI := range filteredFiles {
+			for i, filteredFI := range filteredFiles {
 				duplicate = os.SameFile(toTestFi, filteredFI.FileInfo)
 				if duplicate {
+					filteredFiles[i].DuplicatePaths = append(filteredFiles[i].DuplicatePaths, toTest.Path)
 					break
 				}
 			}


### PR DESCRIPTION
Solves the case where you have two sets of duplicate files, where at least one set has hardlinked copies, that running gourd -makehardlinks does not re-link all of the hardlinks. Previously, this require could require re-running gourd multiple times before all duplicates are hardlinked properly.